### PR TITLE
Add missing closing bracket for extern "C"

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -105,5 +105,9 @@ extern "C" {
 void crypto_zero(void *dest, size_t len);
 bool crypto_equal(const void *a, const void *b, size_t size);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _CRYPTO_H_ */
 


### PR DESCRIPTION
There is a missing closing bracket for `extern "C"` in crypto.h file.