### PR TITLE
ci: replace `master` with `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
      branches:
-        - master
+        - main
 
   # include workflow_dispatch to enable manual trigger from Web UI.
   workflow_dispatch:


### PR DESCRIPTION
the default branch is not master, but main