### PR TITLE
Change TAI64N timestamp source to gettimeofday

### DIFF
--- a/src/wireguard-platform.c
+++ b/src/wireguard-platform.c
@@ -1,6 +1,7 @@
 #include "wireguard-platform.h"
 
 #include <stdlib.h>
+#include <time.h>
 #include <inttypes.h>
 #include <lwip/sys.h>
 #include <mbedtls/entropy.h>
@@ -73,11 +74,11 @@ void wireguard_tai64n_now(uint8_t *output) {
 	// 64 bit seconds from 1970 = 8 bytes
 	// 32 bit nano seconds from current second
 
-	uint64_t millis = sys_now();
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
 
-	// Split into seconds offset + nanos
-	uint64_t seconds = 0x400000000000000aULL + (millis / 1000);
-	uint32_t nanos = (millis % 1000) * 1000;
+	uint64_t seconds = 0x400000000000000aULL + tv.tv_sec;
+	uint32_t nanos = tv.tv_usec * 1000;
 	U64TO8_BIG(output + 0, seconds);
 	U32TO8_BIG(output + 8, nanos);
 }


### PR DESCRIPTION
This pull request fixes the behaviour which prevents the ESP32 device from reconnecting after reset (as reported in #29) by supplying time from source which can be synchronized with a SNTP service or an external RTC device.
As mentioned [here](https://www.wireguard.com/protocol/#dos-mitigation), WireGuard implements timestamps as a countermeasure for replay attacks.
Which means handshakes with timestamps lower than previously encountered will be discarded.
And since the current implementation uses _sys_now_, the supplied time is being reset along with the device.